### PR TITLE
Added GPTmanager code w/ prompts

### DIFF
--- a/backend/GPTManager.py
+++ b/backend/GPTManager.py
@@ -1,21 +1,70 @@
+from openai import OpenAI
+
+
+SYSTEM_PROMPT = """
+You are a helpful assistant which will inform users about ecolabels.
+In this chat, you will discuss the {name} ecolabel from {organization}.
+Some information to assist the user with is: {description}.
+"""
+
+USER_PROMPT = """
+Give me a short but detailed description about the {name} ecolabel from {organization}.
+"""
+
+
 class GPTManager:
     """
     Handles all interactions with OpenAI/GPT
-    
+
     Attributes:
         api_key (string): A string representing the OpenAI key being used
     """
+
     def __init__(self, api_key):
         self.api_key = api_key
-    
-    def get_resp(self, prompt):
+        self.model = "gpt-4o-mini"
+        self.client = OpenAI(api_key)
+
+    def init_chat(info):
+        """
+        Creates an initial chat based on data from the dict
+
+        Args:
+            info (dict): A dictionary of ecolabel info for the prompt
+
+        Returns:
+            chat (List[Tuple[string, string]]): The starting chat list of (user, message) tuples
+        """
+        system_prompt = SYSTEM_PROMPT.format(**info)
+        user_prompt = USER_PROMPT.format(**info)
+        return [("system", system_prompt), ("user", user_prompt)]
+
+    def get_resp(self, chat):
         """
         Sends the given prompt to OpenAI and retrieves the response
-        
+
         Args:
-            prompt (string): The full string prompt to give to OpenAI
+            chat (List[Tuple[string, string]]): The full chat of the user
 
         Returns:
             response (string): The response from OpenAI
         """
-        raise NotImplementedError()
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=self._get_messages_from_chat(chat),
+            temperature=0.1,
+        )
+        return response
+
+    def _get_messages_from_chat(chat):
+        """
+        Formats the chat to be in the format used by the openai API
+
+        Args:
+            chat (List[Tuple[string, string]]): The full chat of the user
+
+        Returns:
+            prompt (List[dict]): The formated prompt to give to OpenAI
+        """
+        prompt = [{"role": user, "content": text} for user, text in chat]
+        return prompt

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 python-dotenv
 pyjwt
+openai


### PR DESCRIPTION
Closes #12 
- Don't really have a way to test get_resp since I don't have access to the API key. But it should work based on the openai API examples. 
- The prompts are in an early stage since I still don't know what info we have/which info the ai should focus on. That being said, its easy to change once this stuff is known.
- This assumes that chat context is stored in a list of tuples in the form (role, message)